### PR TITLE
Convert to plugin2.

### DIFF
--- a/lib/Dancer2/Plugin/Locale.pm
+++ b/lib/Dancer2/Plugin/Locale.pm
@@ -18,21 +18,23 @@ use File::Spec;
 
 # use Tie::Hash::ReadonlyStack;
 
-register locale => sub {
+plugin_keywords 'locale';
+
+sub locale {
     my $dsl = shift;
 
     if (@_) {
         return Dancer2::Plugin::Locale::Obj->get_handle( grep( { defined } (@_) ), 'en' );    # multiton already via Locale::Maketext::Utils
     }
 
-    my $conf = plugin_setting();
+    my $conf = $dsl->config;
     my $app  = $dsl->app;
 
     # TODO 2: request locale via browser/HTP req after session and before default?
-    return Dancer2::Plugin::Locale::Obj->get_handle( grep( { defined } ( eval { $app->session->read('locale') }, $conf->{default_locale} ) ), 'en' );    # multiton already via Locale::Maketext::Utils
+    return Dancer2::Plugin::Locale::Obj->get_handle( grep( { defined } ( eval { $app->session->read('locale') }, $dsl->config->{default_locale} ) ), 'en' );    # multiton already via Locale::Maketext::Utils
 };
 
-on_plugin_import {
+sub BUILD {
     my $dsl = shift;
 
     my @available_locales = ('en');
@@ -99,8 +101,6 @@ sub _from_json_file {
 
 # TODO 2: localization tips
 # TODO 2: extractor/checker tool
-
-register_plugin;
 
 1;
 


### PR DESCRIPTION
Next Dancer2 release includes a major overhaul to Plugin (known as plugin2) which breaks this plugin. Attempts have been made to prevent breakage of existing plugins but this is not possible in all cases (like this one) so a new release of this plugin will be needed as soon as next Dancer2 release occurs.

If you would like me to handle the next release of this plugin in sync with Dancer2 please let me have co-maint and I will sort. I have a handful of other plugins to release at the same time so one more is no big deal.
